### PR TITLE
Add params to extra hash

### DIFF
--- a/lib/omniauth/strategies/quickbooks_oauth2.rb
+++ b/lib/omniauth/strategies/quickbooks_oauth2.rb
@@ -21,7 +21,10 @@ module OmniAuth
       end
 
       extra do
-        { raw_info: raw_info }
+        {
+          raw_info: raw_info,
+          params: access_token.params,
+        }
       end
 
       def raw_info


### PR DESCRIPTION
Add `access_token.params` to extra.
This allows to read quickbooks' [x_refresh_token_expires_in](https://developer.intuit.com/app/developer/qbo/docs/develop/authentication-and-authorization/oauth-2.0#step-5-exchange-authorization-code-for-refresh-and-access-tokens) parameter located in `access_token.params`